### PR TITLE
If VRF fails to deliver a random number, only the admin can decide the outcome

### DIFF
--- a/contracts/WinnablesTicketManager.sol
+++ b/contracts/WinnablesTicketManager.sol
@@ -492,6 +492,7 @@ contract WinnablesTicketManager is
                 blocksSinceLastRequest = block.number - _chainlinkRequests[raffleId].blockLastRequested;
             }
             if (blocksSinceLastRequest > VRF_REQUEST_TIMEOUT) {
+                _checkRole(msg.sender, 0);
                 return;
             }
         }
@@ -514,6 +515,16 @@ contract WinnablesTicketManager is
 
     function _checkShouldCancel(uint256 raffleId) internal view {
         Raffle storage raffle = _raffles[raffleId];
+        if (raffle.status == RaffleStatus.REQUESTED) {
+            uint256 blocksSinceLastRequest;
+            unchecked {
+                blocksSinceLastRequest = block.number - _chainlinkRequests[raffleId].blockLastRequested;
+            }
+            if (blocksSinceLastRequest > VRF_REQUEST_TIMEOUT) {
+                _checkRole(msg.sender, 0);
+                return;
+            }
+        }
         if (raffle.status == RaffleStatus.PRIZE_LOCKED) {
             _checkRole(msg.sender, 0);
             return;

--- a/contracts/interfaces/IWinnablesTicketManager.sol
+++ b/contracts/interfaces/IWinnablesTicketManager.sol
@@ -11,6 +11,7 @@ interface IWinnablesTicketManager is IWinnables {
     error MaxTicketExceed();
 
     event RafflePrizeLocked(bytes32 messageId, uint64 sourceChainSelector, uint256 raffleId);
+    event InvalidVRFRequest(uint256 requestId);
 
     enum CCIPMessageType {
         RAFFLE_CANCELED,

--- a/contracts/mock/VRFCoordinatorV2_5BetterMock.sol
+++ b/contracts/mock/VRFCoordinatorV2_5BetterMock.sol
@@ -112,9 +112,9 @@ contract VRFCoordinatorV2_5BetterMock is VRF {
         if (!s_consumers[subId][msg.sender]) revert();
         if (req.requestConfirmations < minConfirmations) revert();
 
-        requestId = s_currentReqId;
+        requestId = uint256(keccak256(abi.encode(s_currentReqId)));
         s_requests[requestId] = msg.sender;
-        s_currentReqId = requestId + 1;
+        s_currentReqId += 1;
         s_requestSubs[requestId] = subId;
         emit RandomWordsRequested(
             req.keyHash,


### PR DESCRIPTION
If Chainlink VRF would stop working for some reason, it's still possible to recover either by waiting until VRF recovers and drawing the raffle again or by cancelling the raffle.

Only the admin can perform the recovery actions and they can decide whichever route they want.

What I anticipate is that if a scenario like that happened, we would poll the participants to know what to do.

It is to be noted that while the raffle is in this state of limbo, everyone is losing. The prize is locked in the prize manager, the proceeds from the ticket sales are locked in the ticket manager, they can't be refunded or claimed by the admin. The only way we can get out of this uncomfortable situation (for everyone) is to either cancel the raffle (players get refunded and the admin can get their prize back) or to actually draw the raffle and propagate the winner (the winner gets their prize and the admin can claim the proceeds from ticket sales).

What that in mind, it's very clear that the incentive for the admin is to make sure we reach one of the 2 happy outcomes